### PR TITLE
fixed settlement amount in dashboard

### DIFF
--- a/src/pages/Dashboard/Overview/Overview.tsx
+++ b/src/pages/Dashboard/Overview/Overview.tsx
@@ -27,7 +27,7 @@ export default function Overview() {
   });
   const [schoolLength, setSchoolLength] = useState(0);
   const settledAmount = getSettlementAmount(
-    settlementData?.getSettlementReportsSubTrustee,
+    settlementData?.getSettlementReportsSubTrustee?.data,
   );
   const {
     data: transactionReport,


### PR DESCRIPTION
The `getSettlementAmount` function expects an array as input, but an object was being passed. This issue has been fixed by passing the correct data array to the function.