### PR TITLE
Feature/reset password

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "graphql": "^16.8.1",
     "html2canvas": "^1.4.1",
     "jspdf": "^3.0.2",
+    "jwt-decode": "^4.0.0",
     "lottie-react": "^2.4.1",
     "prettier": "^3.6.2",
     "pretty-quick": "^4.2.2",
@@ -39,6 +40,7 @@
   "devDependencies": {
     "@eslint/js": "^9.33.0",
     "@types/date-fns": "^2.5.3",
+    "@types/jwt-decode": "^2.2.1",
     "@types/node": "^24.3.1",
     "@types/react": "^19.1.10",
     "@types/react-date-range": "^1.4.10",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import "./App.css";
 
 import ProtectedRoute from "./components/ProtectedRoute";
 import Login from "./pages/Authentication/Login";
+import ResetPassword from "./pages/Authentication/ResetPassword";
 import Dashboard from "./pages/Dashboard/Dashboard";
 import PublicRoute from "./components/PublicRoute";
 import Overview from "./pages/Dashboard/Overview/Overview";
@@ -27,6 +28,14 @@ function App() {
   return (
     <>
       <Routes>
+        <Route
+          path="/reset-password"
+          element={
+            <PublicRoute>
+              <ResetPassword />
+            </PublicRoute>
+          }
+        />
         <Route
           path="/login"
           element={

--- a/src/Qurries.ts
+++ b/src/Qurries.ts
@@ -632,3 +632,27 @@ export const CREATE_INSTITUTE = gql`
     }
   }
 `;
+
+export const RESET_MAILS = gql`
+  mutation ResetMails($email: String!) {
+    resetMails(email: $email) {
+      active
+    }
+  }
+`;
+
+export const RESET_PASSWORD = gql`
+  mutation ResetPassword($email: String!, $password: String!) {
+    resetPassword(email: $email, password: $password) {
+      msg
+    }
+  }
+`;
+
+export const VERIFY_TOKEN = gql`
+  query VerifyToken($token: String!) {
+    verifyToken(token: $token) {
+      active
+    }
+  }
+`;

--- a/src/components/Reports/Reports.tsx
+++ b/src/components/Reports/Reports.tsx
@@ -243,6 +243,10 @@ export default function Reports() {
                   value: "VENDOR_TRANSACTION_REPORT",
                   label: "Vendor Transaction Report",
                 },
+                {
+                  value: "COMMISSION_REPORT",
+                  label: "Commission Report",
+                }
                 // { value: "dispute", label: "Dispute Report" },
               ]}
               isSearchable={false}

--- a/src/pages/Authentication/Login.tsx
+++ b/src/pages/Authentication/Login.tsx
@@ -2,7 +2,9 @@ import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext";
 import { useState } from "react";
 import { useLazyQuery, useMutation } from "@apollo/client";
-import { GET_USER, LOG_IN_TRUSTEE } from "../../Qurries";
+import { GET_USER, LOG_IN_TRUSTEE, RESET_MAILS } from "../../Qurries";
+import { toast } from "react-toastify";
+import Modal from "../../components/Modal/Modal";
 import { FaEye, FaEyeSlash, FaSpinner } from "react-icons/fa";
 import EdvironLogo from "../../assets/logo.svg";
 import LogoSvg from "../../assets/voice_control_ofo1.svg";
@@ -15,6 +17,10 @@ function Login() {
   const [loginMutation, { loading }] = useMutation(LOG_IN_TRUSTEE);
   const [fetchUser] = useLazyQuery(GET_USER);
   const [passwordVisible, setPasswordVisible] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [resetEmail, setResetEmail] = useState("");
+  const [showLoadingModal, setShowLoadingModal] = useState(false);
+  const [resetMailsMutation] = useMutation(RESET_MAILS);
   const handleLogin = async () => {
     try {
       const data = await loginMutation({ variables: { email, password } });
@@ -30,6 +36,25 @@ function Login() {
     } catch (err) {
       console.error(err);
       navigate("/login");
+    }
+  };
+
+  const resetPass = async (email: string) => {
+    try {
+      setShowLoadingModal(true);
+      const { data } = await resetMailsMutation({ variables: { email } });
+      if (data && data.resetMails && data.resetMails.active) {
+        setShowLoadingModal(false);
+        toast.success("Password reset email sent successfully.");
+        setShowModal(false);
+      } else {
+        setShowLoadingModal(false);
+        toast.error("Error sending reset email. Please check your email.");
+      }
+    } catch (error: any) {
+      setShowLoadingModal(false);
+      console.error("Error sending reset email:", error.message);
+      toast.error("Error sending reset email. Try again later.");
     }
   };
   return (
@@ -109,16 +134,16 @@ function Login() {
             </button>
           </div>
         </form>
-        {/* <div className="md:max-w-[25rem] w-full mt-2">
+        <div className="md:max-w-[25rem] w-full mt-2">
           <button
-            //onClick={() => setShowModal(!showModal)}
+            onClick={() => setShowModal(!showModal)}
             className="bg-[#d6daf3] w-full px-4 py-3 mt-4 rounded-lg"
           >
             Reset Password
           </button>
-        </div> */}
+        </div>
       </div>
-      {/* <Modal
+      <Modal
         className="max-w-lg w-full"
         open={showModal}
         setOpen={setShowModal}
@@ -128,7 +153,6 @@ function Login() {
           onSubmit={async (e) => {
             e.preventDefault();
             try {
-              // Call resetPass function with the current email state
               await resetPass(resetEmail);
             } catch (error: any) {
               console.error("Error sending reset email:", error.message);
@@ -150,7 +174,16 @@ function Login() {
             </button>
           </div>
         </form>
-      </Modal> */}
+      </Modal>
+      <Modal
+        className="max-w-lg w-full"
+        open={showLoadingModal}
+        setOpen={setShowLoadingModal}
+      >
+        <div className="w-full h-full flex">
+          <FaSpinner className="m-auto animate-spin size-8" />
+        </div>
+      </Modal>
       {/* <Modal
         className="max-w-lg w-full"
         open={showLoadingModal}

--- a/src/pages/Authentication/ResetPassword.tsx
+++ b/src/pages/Authentication/ResetPassword.tsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useState } from "react";
+// lightweight JWT payload decode (no external dependency)
+import { jwtDecode } from "jwt-decode";
+import { useNavigate } from "react-router-dom";
+import { RESET_PASSWORD, VERIFY_TOKEN } from "../../Qurries";
+import { useMutation, useQuery } from "@apollo/client";
+import { toast } from "react-toastify";
+import LogoSvg from "../../assets/voice_control_ofo1.svg";
+
+const ResetPassword = () => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const navigate = useNavigate();
+
+  const [resetPasswordMutation] = useMutation(RESET_PASSWORD);
+  const urlParams = new URLSearchParams(window.location.search);
+  const token = urlParams.get("token") || "";
+  const { data } = useQuery(VERIFY_TOKEN, {
+    variables: { token },
+    skip: !token,
+  });
+
+  useEffect(() => {
+    if (data && !data.verifyToken.active) {
+      toast.error("Link Expire redirecting to login page");
+      setTimeout(() => {
+        navigate("/login");
+      }, 3000);
+    }
+  }, [data, token, navigate]);
+  useEffect(() => {
+    if (token) {
+      const decodedToken = jwtDecode(token) as any;
+      setEmail(decodedToken.email);
+    }
+  }, [token]);
+
+  const isResetButtonDisabled = password === "" || password !== confirmPassword;
+
+  const handleResetPassword = async (e: any) => {
+    e.preventDefault();
+    try {
+      const { data } = await resetPasswordMutation({ variables: { email, password } });
+      const msg = data?.resetPassword?.msg || "Password reset successfully!";
+      toast.success(msg + " Redirecting to login.");
+
+      setTimeout(() => {
+        navigate("/login");
+      }, 3000);
+    } catch (error: any) {
+      console.error("Error resetting password", error.message);
+      toast.error("Error resetting password. Try again later.");
+    }
+  };
+
+  return (
+    <div className="w-full h-screen grid gap-x-8 lg:!grid-cols-5 grid-cols-1">
+      <div className=" col-span-2 w-full flex flex-col lg:items-start items-center md:p-20 px-10 py-20 bg-[#eceefa] xl:rounded-r-[20px]">
+        <div></div>
+        <div className="mt-20">
+          <h3 className="font-bold text-2xl">Reset your password</h3>
+        </div>
+
+        <form onSubmit={handleResetPassword} className="md:max-w-[25rem] w-full space-y-4 mt-12">
+          <div className="flex flex-col gap-y-2">
+            <label className="capitalize font-medium text-base" htmlFor="emailId">
+              email
+            </label>
+            <div className="bg-white w-full border border-gray-200 rounded-lg overflow-hidden">
+              <input type="email" className="w-full p-3 px-4 focus:outline-none" id="emailId" required value={email} readOnly />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-y-2">
+            <label className="capitalize font-medium text-base" htmlFor="password">
+              Password
+            </label>
+            <div className="bg-white w-full border border-gray-200 rounded-lg overflow-hidden">
+              <input type="password" className="w-full p-3 px-4 focus:outline-none" id="password" onChange={(e) => setPassword(e.target.value)} placeholder="New Password" required />
+            </div>
+          </div>
+          <div className="flex flex-col gap-y-2">
+            <label className="capitalize font-medium text-base" htmlFor="confirm">
+              Confirm Password
+            </label>
+            <div className="bg-white w-full border border-gray-200 rounded-lg overflow-hidden">
+              <input type="password" className="w-full p-3 px-4 focus:outline-none" id="confirm" onChange={(e) => setConfirmPassword(e.target.value)} placeholder="Confirm Password" required />
+            </div>
+          </div>
+          {isResetButtonDisabled ? (
+            <button className="bg-gray-300 text-gray-600 w-full px-4 py-3 mt-4 rounded-lg" disabled>
+              Reset
+            </button>
+          ) : (
+            <div className="bg-[#d6daf3]  mt-4 rounded-lg">
+              <button className=" w-full  px-4 py-3" type="submit">
+                Reset
+              </button>
+            </div>
+          )}
+        </form>
+      </div>
+      <div className="col-span-3 w-full hidden lg:flex items-center px-32 justify-center">
+        <img src={LogoSvg} className="w-full h-full" alt="" />
+      </div>
+    </div>
+  );
+};
+
+export default ResetPassword;


### PR DESCRIPTION
**Summary**
- **Purpose:** Add password-reset UX and backend GraphQL hooks to enable "forgot password" flows and small reports selector update.
- **Scope:** Frontend pages/components and GraphQL operations; a dependency addition.

**What I changed**
- **Feature:** Add `ResetPassword` page and route, plus token verification and reset flow.
- **Feature:** Add reset-password modal to `Login` with `RESET_MAILS` mutation and loading state.
- **API:** Add GraphQL operations `RESET_MAILS`, `RESET_PASSWORD`, `VERIFY_TOKEN` to frontend queries.
- **UI:** Add "Commission Report" option to reports selector.
- **Deps:** Add `jwt-decode` and `@types/jwt-decode` to package.json for token decoding.
- **Docs:** Add backend implementation notes for reset-password flow.

**Files**
- **Page / Route:** ResetPassword.tsx
- **Login updates:** Login.tsx
- **App route:** App.tsx
- **GraphQL ops:** Qurries.ts
- **Reports UI:** Reports.tsx
- **Deps:** package.json 
