### PR TITLE
Add bank details to institute GraphQL query

### DIFF
--- a/src/Qurries.ts
+++ b/src/Qurries.ts
@@ -83,11 +83,15 @@ export const GET_INSTITUTES = gql`
         updatedAt
         gstIn
         residence_state
+        bank_details {
+          account_holder_name
+          account_number
+          ifsc_code
+        }
       }
     }
   }
 `;
-
 export const GET_TRANSACTIONS = gql`
   query GetSubtrusteeTransactionReport(
     $startDate: String


### PR DESCRIPTION
**Summary**
This PR adds `bank_details` (account holder name, account number, IFSC) to the `GET_INSTITUTES` GraphQL query so institute responses include bank information for display and settlement purposes.

**Changes**
- Qurries.ts
  - Added `bank_details { account_holder_name account_number ifsc_code }` fields to `GET_INSTITUTES`.

**Why**
We need institute bank information in the frontend to show payment/settlement details and support vendor/institute reconciliation flows.
